### PR TITLE
Fix build with updated go-openai version

### DIFF
--- a/PaperSecBot.go
+++ b/PaperSecBot.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/url"
 	"os"

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.24.3
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
-	github.com/sashabaranov/go-openai v1.15.0
+	github.com/sashabaranov/go-openai v1.40.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
+github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
+github.com/sashabaranov/go-openai v1.40.5 h1:SwIlNdWflzR1Rxd1gv3pUg6pwPc6cQ2uMoHs8ai+/NY=
+github.com/sashabaranov/go-openai v1.40.5/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=


### PR DESCRIPTION
## Summary
- update go-openai module to v1.40.5
- generate `go.sum`
- remove unused `fmt` import

## Testing
- `go mod tidy`
- `go build -o papersecbot .`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d772e6f6c8321b15c570333a28ea1