### PR TITLE
Add Telegram send error handling

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"context"
 	"errors"
+	"log"
 	"strings"
 	"sync"
 
@@ -114,5 +115,10 @@ func (b *Bot) HandleText(m *tgbotapi.Message) {
 func (b *Bot) send(chatID int64, text string) {
 	msg := tgbotapi.NewMessage(chatID, text)
 	msg.ParseMode = markdownMode
-	_, _ = b.TG.Send(msg)
+	if _, err := b.TG.Send(msg); err != nil {
+		log.Printf("telegram send failed: %v", err)
+		if _, err := b.TG.Send(msg); err != nil {
+			log.Printf("telegram send retry failed: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- log Telegram send errors and retry once in `Bot.send`

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687de0e49c70832186e6945e6f6ad07c