### PR TITLE
Add AI client interface and tests

### DIFF
--- a/internal/openaiutil/extract_test.go
+++ b/internal/openaiutil/extract_test.go
@@ -1,0 +1,47 @@
+package openaiutil
+
+import (
+	"context"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type mockAI struct {
+	resp openai.ChatCompletionResponse
+	err  error
+}
+
+func (m *mockAI) CreateChatCompletion(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+	return m.resp, m.err
+}
+
+func TestExtractFieldsDefaults(t *testing.T) {
+	desc := "See https://example.com/path"
+	got, err := ExtractFields(nil, desc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Assets != "example.com" {
+		t.Errorf("assets=%s want example.com", got.Assets)
+	}
+	if got.ShortDesc != desc {
+		t.Errorf("short desc=%s want %s", got.ShortDesc, desc)
+	}
+	if got.Severity != defaultSeverity {
+		t.Errorf("severity=%s want %s", got.Severity, defaultSeverity)
+	}
+}
+
+func TestExtractFieldsAI(t *testing.T) {
+	m := &mockAI{resp: openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{Message: openai.ChatCompletionMessage{Content: `{"Severity":"Medium","Name":"SQL","CVSSScore":6.1,"CVSSVector":"AV:N","Assets":"test.com","ShortDesc":"desc","ScreenshotHints":"hint","Remediation":"fix"}`}}},
+	}}
+	got, err := ExtractFields(m, "text")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Severity != "Medium" || got.Name != "SQL" || got.CVSSScore != "6.1" || got.CVSSVector != "AV:N" || got.Assets != "test.com" || got.ShortDesc != "desc" || got.ScreenshotHints != "hint" || got.Remediation != "fix" {
+		t.Errorf("unexpected result: %+v", got)
+	}
+}

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
-	openai "github.com/sashabaranov/go-openai"
 
 	"papersecbot/internal/openaiutil"
 )
@@ -71,15 +70,20 @@ func (p *pendingChats) Cancel(id int64) bool {
 // Bot represents a Telegram bot with an optional OpenAI backend.
 // TG is the Telegram API client, OA is the OpenAI client (may be nil),
 // and Pending tracks chats currently describing a bug.
+// Bot represents a Telegram bot with an optional OpenAI backend.
+// TG is the Telegram API client, OA is the OpenAI client (may be nil),
+// and Pending tracks chats currently describing a bug.
 type Bot struct {
 	TG      *tgbotapi.BotAPI
-	OA      *openai.Client
+	OA      openaiutil.AIClient
 	Pending *pendingChats
 }
 
 // New constructs a Bot instance from Telegram and OpenAI clients. The
 // OpenAI client can be nil to disable description enrichment.
-func New(tg *tgbotapi.BotAPI, oa *openai.Client) *Bot {
+// New constructs a Bot instance from Telegram and OpenAI clients. The
+// OpenAI client can be nil to disable description enrichment.
+func New(tg *tgbotapi.BotAPI, oa openaiutil.AIClient) *Bot {
 	return &Bot{TG: tg, OA: oa, Pending: newPendingChats()}
 }
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	openai "github.com/sashabaranov/go-openai"
 
+	"papersecbot/internal/openaiutil"
 	"papersecbot/internal/telegram"
 )
 
@@ -21,7 +22,7 @@ func main() {
 	}
 	log.Printf("Authorized as %s", tg.Self.UserName)
 
-	var oa *openai.Client
+	var oa openaiutil.AIClient
 	if k := os.Getenv("OPENAI_API_KEY"); k != "" {
 		oa = openai.NewClient(k)
 	}


### PR DESCRIPTION
## Summary
- add `AIClient` interface to allow mocking OpenAI API
- update `ExtractFields` and `Bot` to use the interface
- wire the interface in `main.go`
- create a mock client and unit tests for `ExtractFields`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687defe15bd0832191f51d0879ef9f73