### PR TITLE
Improve GoDoc coverage

### DIFF
--- a/internal/openaiutil/openai.go
+++ b/internal/openaiutil/openai.go
@@ -77,8 +77,6 @@ func ParseDomain(text string) string {
 	return placeholder
 }
 
-// BuildMarkdown formats the report into a Markdown block suitable for
-// sending back via Telegram.
 func escapeMarkdown(s string) string {
 	replacer := strings.NewReplacer(
 		"*", "\\*",
@@ -88,6 +86,8 @@ func escapeMarkdown(s string) string {
 	return replacer.Replace(s)
 }
 
+// BuildMarkdown formats the Report into a human readable Markdown block that
+// can be sent back to the user via Telegram.
 func BuildMarkdown(r Report) string {
 	val := func(s string) string {
 		if s == "" {

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -67,22 +67,18 @@ func (p *pendingChats) Cancel(id int64) bool {
 	return ok
 }
 
-// Bot represents a Telegram bot with an optional OpenAI backend.
-// TG is the Telegram API client, OA is the OpenAI client (may be nil),
-// and Pending tracks chats currently describing a bug.
-// Bot represents a Telegram bot with an optional OpenAI backend.
-// TG is the Telegram API client, OA is the OpenAI client (may be nil),
-// and Pending tracks chats currently describing a bug.
+// Bot wraps a Telegram client and optionally an OpenAI client.
+// TG is the Telegram API client, OA may be nil when OpenAI integration is
+// disabled, and Pending tracks chats that are in the middle of describing a
+// bug.
 type Bot struct {
 	TG      *tgbotapi.BotAPI
 	OA      openaiutil.AIClient
 	Pending *pendingChats
 }
 
-// New constructs a Bot instance from Telegram and OpenAI clients. The
-// OpenAI client can be nil to disable description enrichment.
-// New constructs a Bot instance from Telegram and OpenAI clients. The
-// OpenAI client can be nil to disable description enrichment.
+// New creates a Bot from Telegram and OpenAI clients. Passing a nil OpenAI
+// client disables description enrichment.
 func New(tg *tgbotapi.BotAPI, oa openaiutil.AIClient) *Bot {
 	return &Bot{TG: tg, OA: oa, Pending: newPendingChats()}
 }


### PR DESCRIPTION
## Summary
- clarify documentation for the `Bot` type and constructor
- document Markdown builder in `openaiutil`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687df6ba8f308321a1e02f05255abf08