### PR TITLE
Fix go version parsing in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module papersecbot
 
-go 1.24.3
+go 1.24
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1


### PR DESCRIPTION
## Summary
- fix `go.mod` directive to use `go 1.24`

## Testing
- `go build -v ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dfa29af308321b944a4f18a5e63f4