### PR TITLE
Fix build by using Go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module papersecbot
 
-go 1.24
+go 1.20
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1


### PR DESCRIPTION
## Summary
- adjust the go version in go.mod from 1.24 to 1.20

## Testing
- `go build -v ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dfd195928832182202acba1f7f3d3