### PR TITLE
Rename variables for clarity

### DIFF
--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -83,8 +83,8 @@ type Bot struct {
 
 // New creates a Bot from Telegram and OpenAI clients. Passing a nil OpenAI
 // client disables description enrichment.
-func New(tg *tgbotapi.BotAPI, oa openaiutil.AIClient) *Bot {
-	return &Bot{TelegramBot: tg, OpenAIClient: oa, Pending: newPendingChats()}
+func New(telegramBot *tgbotapi.BotAPI, openAIClient openaiutil.AIClient) *Bot {
+	return &Bot{TelegramBot: telegramBot, OpenAIClient: openAIClient, Pending: newPendingChats()}
 }
 
 // HandleCmd processes bot commands such as /start, /bug and /cancel. Any


### PR DESCRIPTION
## Summary
- clarify variable names for Telegram and OpenAI clients
- consistently name update variable in main loop

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687e081adf9c832181745f88ce0e2ca3