### PR TITLE
Refactor tests for separation of concerns

### DIFF
--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -1,0 +1,42 @@
+package formatter_test
+
+import (
+	"strings"
+	"testing"
+
+	"papersecbot/internal/formatter"
+	openaiutil "papersecbot/internal/openaiutil"
+)
+
+func TestBuildMarkdown(t *testing.T) {
+	r := openaiutil.Report{
+		Severity:        "High",
+		Name:            "XSS at https://evil.com",
+		CVSSScore:       "7.5",
+		CVSSVector:      "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+		Assets:          "test.com",
+		ShortDesc:       "<script>",
+		ScreenshotHints: "Look at console",
+		Remediation:     "Escape < > &",
+	}
+	md := formatter.BuildMarkdown(r)
+	if strings.Contains(md, "https://evil.com") {
+		t.Errorf("url not stripped from name: %s", md)
+	}
+	if !strings.Contains(md, "[High] XSS at") {
+		t.Errorf("severity/name missing: %s", md)
+	}
+}
+
+func TestBuildMarkdownEmpty(t *testing.T) {
+	r := openaiutil.Report{}
+	md := formatter.BuildMarkdown(r)
+	for _, field := range []string{"**[", "CVSS:", "Затронутые активы:", "Описание:", "*", "Рекомендации:"} {
+		if !strings.Contains(md, field) {
+			t.Errorf("missing field marker %s", field)
+		}
+	}
+	if count := strings.Count(md, formatter.Placeholder); count < 5 {
+		t.Errorf("expected placeholder inserted, got %d", count)
+	}
+}

--- a/internal/openaiutil/openai.go
+++ b/internal/openaiutil/openai.go
@@ -38,9 +38,9 @@ const (
 	systemPrompt          = "Ты Russian security-аналитик. Ответ JSON minified безбэктиков. Ключи: Severity, Name, CVSSScore, CVSSVector, Assets, ShortDesc, ScreenshotHints, Remediation. Severity на английском. ShortDesc — техническое описание на русском с PoC и влиянием. ScreenshotHints — русские подсказки какие скриншоты/артефакты/POC приложить. Remediation — детальные шаги с ссылками PortSwigger, Nessus и Acunetix (рус)."
 )
 
-// Report contains all fields needed for a vulnerability description
-// that will be sent back to the user. Each field corresponds to a
-// part of the Markdown template built by formatter.BuildMarkdown.
+// Report contains the vulnerability information extracted from the
+// description and returned by OpenAI. Each field maps to a section in
+// the formatted report produced by the formatter package.
 type Report struct {
 	Severity        string
 	Name            string

--- a/internal/openaiutil/openai_test.go
+++ b/internal/openaiutil/openai_test.go
@@ -1,7 +1,6 @@
 package openaiutil_test
 
 import (
-	"strings"
 	"testing"
 
 	"papersecbot/internal/formatter"
@@ -23,38 +22,5 @@ func TestParseDomain(t *testing.T) {
 		if got := openaiutil.ParseDomain(tt.in); got != tt.want {
 			t.Errorf("%d: ParseDomain(%q)=%q want %q", i, tt.in, got, tt.want)
 		}
-	}
-}
-
-func TestBuildMarkdown(t *testing.T) {
-	r := openaiutil.Report{
-		Severity:        "High",
-		Name:            "XSS at https://evil.com",
-		CVSSScore:       "7.5",
-		CVSSVector:      "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
-		Assets:          "test.com",
-		ShortDesc:       "<script>",
-		ScreenshotHints: "Look at console",
-		Remediation:     "Escape < > &",
-	}
-	md := formatter.BuildMarkdown(r)
-	if strings.Contains(md, "https://evil.com") {
-		t.Errorf("url not stripped from name: %s", md)
-	}
-	if !strings.Contains(md, "[High] XSS at") {
-		t.Errorf("severity/name missing: %s", md)
-	}
-}
-
-func TestBuildMarkdownEmpty(t *testing.T) {
-	r := openaiutil.Report{}
-	md := formatter.BuildMarkdown(r)
-	for _, field := range []string{"**[", "CVSS:", "Затронутые активы:", "Описание:", "*", "Рекомендации:"} {
-		if !strings.Contains(md, field) {
-			t.Errorf("missing field marker %s", field)
-		}
-	}
-	if count := strings.Count(md, formatter.Placeholder); count < 5 {
-		t.Errorf("expected placeholder inserted, got %d", count)
 	}
 }


### PR DESCRIPTION
## Summary
- keep openaiutil strictly for OpenAI interaction and report construction
- move Markdown formatting tests to formatter package
- clarify Report comment

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e1263097c832181fb53cce4499435